### PR TITLE
腕にキーボードをセット

### DIFF
--- a/Flick Keyboards/Assets/MixedRealityToolkit.Generated/CustomProfiles/MyMixedRealityGesturesProfile.asset
+++ b/Flick Keyboards/Assets/MixedRealityToolkit.Generated/CustomProfiles/MyMixedRealityGesturesProfile.asset
@@ -1,0 +1,45 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7554812f08ec49e694a8d9d4ee235a9c, type: 3}
+  m_Name: MyMixedRealityGesturesProfile
+  m_EditorClassIdentifier: 
+  isCustomProfile: 1
+  manipulationGestures: 13
+  navigationGestures: 112
+  useRailsNavigation: 0
+  railsNavigationGestures: 896
+  windowsGestureAutoStart: 0
+  gestures:
+  - description: Hold
+    gestureType: 1
+    action:
+      id: 8
+      description: Hold Action
+      axisConstraint: 0
+  - description: Navigation
+    gestureType: 2
+    action:
+      id: 10
+      description: Navigation Action
+      axisConstraint: 0
+  - description: Manipulation
+    gestureType: 3
+    action:
+      id: 9
+      description: Manipulate Action
+      axisConstraint: 0
+  - description: Tap
+    gestureType: 4
+    action:
+      id: 1
+      description: Select
+      axisConstraint: 2

--- a/Flick Keyboards/Assets/MixedRealityToolkit.Generated/CustomProfiles/MyMixedRealityGesturesProfile.asset.meta
+++ b/Flick Keyboards/Assets/MixedRealityToolkit.Generated/CustomProfiles/MyMixedRealityGesturesProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 41c3af8172c369b4590ca6199dd30aaa
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Flick Keyboards/Assets/MixedRealityToolkit.Generated/CustomProfiles/MyMixedRealityHandTrackingProfile.asset
+++ b/Flick Keyboards/Assets/MixedRealityToolkit.Generated/CustomProfiles/MyMixedRealityHandTrackingProfile.asset
@@ -22,4 +22,4 @@ MonoBehaviour:
   handMeshPrefab: {fileID: 1887883006053652, guid: a86f479797fea8f4189f924b3b6ad979,
     type: 3}
   handMeshVisualizationModes: 0
-  handJointVisualizationModes: 0
+  handJointVisualizationModes: -1

--- a/Flick Keyboards/Assets/MixedRealityToolkit.Generated/CustomProfiles/MyMixedRealityInputSystemProfile.asset
+++ b/Flick Keyboards/Assets/MixedRealityToolkit.Generated/CustomProfiles/MyMixedRealityInputSystemProfile.asset
@@ -93,7 +93,7 @@ MonoBehaviour:
   inputActionRulesProfile: {fileID: 11400000, guid: 03945385d89102f41855bc8f5116b199,
     type: 2}
   pointerProfile: {fileID: 11400000, guid: 48aa63a9725047b28d4137fd0834bc31, type: 2}
-  gesturesProfile: {fileID: 11400000, guid: bd7829a9b29409045a745b5a18299291, type: 2}
+  gesturesProfile: {fileID: 11400000, guid: 41c3af8172c369b4590ca6199dd30aaa, type: 2}
   speechCommandsProfile: {fileID: 11400000, guid: e8d0393e66374dae9646851a57dc6bc1,
     type: 2}
   enableControllerMapping: 1

--- a/Flick Keyboards/Assets/Prefabs/FlickButton.prefab
+++ b/Flick Keyboards/Assets/Prefabs/FlickButton.prefab
@@ -241,7 +241,7 @@ Transform:
   m_GameObject: {fileID: 1312930847085162460}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.032000005, y: 0.048, z: 1}
-  m_LocalScale: {x: 0.75, y: 0.75, z: 0.75}
+  m_LocalScale: {x: 0.625, y: 0.625, z: 0.625}
   m_Children:
   - {fileID: 1312930846713398438}
   - {fileID: 1084614076253112998}
@@ -262,7 +262,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.032, y: 0.032, z: 0.016}
+  m_Size: {x: 0.024, y: 0.024, z: 0.008}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &1312930847085162434
 MonoBehaviour:

--- a/Flick Keyboards/Assets/Prefabs/FlickButton.prefab
+++ b/Flick Keyboards/Assets/Prefabs/FlickButton.prefab
@@ -241,7 +241,7 @@ Transform:
   m_GameObject: {fileID: 1312930847085162460}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.032000005, y: 0.048, z: 1}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.75, y: 0.75, z: 0.75}
   m_Children:
   - {fileID: 1312930846713398438}
   - {fileID: 1084614076253112998}

--- a/Flick Keyboards/Assets/Prefabs/ResponseBox.prefab
+++ b/Flick Keyboards/Assets/Prefabs/ResponseBox.prefab
@@ -29,7 +29,7 @@ Transform:
   m_GameObject: {fileID: 1991445153779552700}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.032, y: 0.032, z: 0.016}
+  m_LocalScale: {x: 0.024, y: 0.024, z: 0.012}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0

--- a/Flick Keyboards/Assets/Prefabs/ResponseBox.prefab
+++ b/Flick Keyboards/Assets/Prefabs/ResponseBox.prefab
@@ -29,7 +29,7 @@ Transform:
   m_GameObject: {fileID: 1991445153779552700}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.024, y: 0.024, z: 0.012}
+  m_LocalScale: {x: 0.02, y: 0.02, z: 0.02}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0

--- a/Flick Keyboards/Assets/Scenes/Main.unity
+++ b/Flick Keyboards/Assets/Scenes/Main.unity
@@ -141,7 +141,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -238,18 +238,22 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 267519455}
   - {fileID: 64373661}
   - {fileID: 1779222319}
   - {fileID: 2088808316}
   - {fileID: 2139273555}
   - {fileID: 648732646}
+  - {fileID: 751042341}
+  - {fileID: 1806167426}
+  - {fileID: 484086144}
   - {fileID: 255454565}
   - {fileID: 1938142801}
   - {fileID: 1437543846}
   - {fileID: 712849016}
-  - {fileID: 751042341}
   - {fileID: 768812722}
   - {fileID: 13236767}
+  - {fileID: 1305983241}
   - {fileID: 102543591}
   m_Father: {fileID: 0}
   m_RootOrder: 4
@@ -389,14 +393,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 102543590}
   m_LocalRotation: {x: -0.5, y: -0.5, z: -0.5, w: 0.5}
-  m_LocalPosition: {x: 0.1, y: -0.05, z: -0.2}
+  m_LocalPosition: {x: 0.05, y: -0.05, z: -0.2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2042680238}
   - {fileID: 657254298}
   - {fileID: 797501232}
   m_Father: {fileID: 50141924}
-  m_RootOrder: 12
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: -90}
 --- !u!82 &102543592
 AudioSource:
@@ -1012,7 +1016,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1087,7 +1091,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 552499566}
+    m_TransformParent: {fileID: 50141924}
     m_Modifications:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1127,12 +1131,12 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.04
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.01
+      value: -0.22
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1391,6 +1395,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Contents: {fileID: 50141923}
   Specials: {fileID: 552499565}
+  ydist: 0.02
+  buttonangle: 87
+  margin: 0.02
 --- !u!114 &457644287
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1492,7 +1499,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1561,7 +1568,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 552499566}
+    m_TransformParent: {fileID: 50141924}
     m_Modifications:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1576,7 +1583,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1596,17 +1603,17 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.01
+      value: -0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.04
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.01
+      value: -0.22
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1777,7 +1784,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &552499566
 Transform:
   m_ObjectHideFlags: 0
@@ -1786,13 +1793,9 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 552499565}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.018999998, y: -0.024600007, z: 0.22529998}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 267519455}
-  - {fileID: 484086144}
-  - {fileID: 1806167426}
-  - {fileID: 1305983241}
+  m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1976,7 +1979,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2194,7 +2197,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2284,7 +2287,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2379,7 +2382,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2564,7 +2567,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0.07, y: -0.03}
+  m_AnchoredPosition: {x: 0.0551, y: -0.0134}
   m_SizeDelta: {x: 0.22, y: 0.02}
   m_Pivot: {x: 0.5, y: -1}
 --- !u!114 &797501233
@@ -3158,7 +3161,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -3227,7 +3230,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 552499566}
+    m_TransformParent: {fileID: 50141924}
     m_Modifications:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -3242,7 +3245,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -3267,12 +3270,12 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.04
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.01
+      value: -0.08
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -3437,7 +3440,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -4288,7 +4291,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1695430390}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.0187, y: -0.0192, z: 0}
+  m_LocalPosition: {x: 0.0058, y: 0.05, z: 0}
   m_LocalScale: {x: 0.24, y: 0.26, z: 0.010599999}
   m_Children: []
   m_Father: {fileID: 2042680238}
@@ -4624,7 +4627,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -4801,7 +4804,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 552499566}
+    m_TransformParent: {fileID: 50141924}
     m_Modifications:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -4816,7 +4819,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -4836,17 +4839,17 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.01
+      value: 0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.04
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.01
+      value: -0.08
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -5011,7 +5014,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -5307,7 +5310,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}

--- a/Flick Keyboards/Assets/Scenes/Main.unity
+++ b/Flick Keyboards/Assets/Scenes/Main.unity
@@ -136,62 +136,62 @@ PrefabInstance:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 12
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.012
+      value: -0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 100
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.03
+      value: -0.1
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -238,7 +238,6 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 1231922751}
   - {fileID: 64373661}
   - {fileID: 1779222319}
   - {fileID: 2088808316}
@@ -251,10 +250,7 @@ Transform:
   - {fileID: 751042341}
   - {fileID: 768812722}
   - {fileID: 13236767}
-  - {fileID: 267519455}
-  - {fileID: 484086144}
-  - {fileID: 1806167426}
-  - {fileID: 1305983241}
+  - {fileID: 102543591}
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -365,6 +361,208 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 101635057}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &102543590
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 102543591}
+  - component: {fileID: 102543595}
+  - component: {fileID: 102543593}
+  - component: {fileID: 102543594}
+  - component: {fileID: 102543592}
+  m_Layer: 0
+  m_Name: NearMenu
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &102543591
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 102543590}
+  m_LocalRotation: {x: -0.5, y: -0.5, z: -0.5, w: 0.5}
+  m_LocalPosition: {x: 0.1, y: -0.05, z: -0.2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2042680238}
+  - {fileID: 657254298}
+  - {fileID: 797501232}
+  m_Father: {fileID: 50141924}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: -90, y: 0, z: -90}
+--- !u!82 &102543592
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 102543590}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!114 &102543593
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 102543590}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4684083f6dff4a1d8a790bccc354fcf4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  updateLinkedTransform: 0
+  moveLerpTime: 0.5
+  rotateLerpTime: 0.5
+  scaleLerpTime: 0
+  maintainScaleOnInitialization: 1
+  smoothing: 1
+  lifetime: 0
+  referenceDirection: 1
+  minDistance: 0.3
+  maxDistance: 0.6
+  minViewDegrees: 0
+  maxViewDegrees: 20
+  aspectV: 1
+  ignoreAngleClamp: 0
+  ignoreDistanceClamp: 0
+  useFixedVerticalPosition: 1
+  fixedVerticalPosition: -0.4
+  orientToReferenceDirection: 0
+--- !u!114 &102543594
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 102543590}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d1fea68463e4e84b86c395b654f950d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  visualizationObject: {fileID: 0}
+  interactableObject: {fileID: 0}
+  autoFollowAtDistance: 0
+  autoFollowDistance: 2
+  autoFollowTransformTarget: {fileID: 0}
+  autoFollowTriggered:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &102543595
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 102543590}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b55691ad5b034fe6966763a6e23818d2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trackedTargetType: 0
+  trackedHandness: 3
+  trackedHandJoint: 2
+  transformOverride: {fileID: 0}
+  additionalOffset: {x: 0, y: 0, z: 0}
+  additionalRotation: {x: 0, y: 0, z: 0}
+  updateSolvers: 1
 --- !u!1001 &117406338
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -809,62 +1007,62 @@ PrefabInstance:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.012
+      value: -0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.096
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.03
+      value: -0.2
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -889,7 +1087,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 50141924}
+    m_TransformParent: {fileID: 552499566}
     m_Modifications:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -899,62 +1097,77 @@ PrefabInstance:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.625
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.625
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.625
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 12
+      value: -0.04
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.03
+      value: -0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1065,6 +1278,85 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 419269803}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &439113853
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 439113854}
+  - component: {fileID: 439113856}
+  - component: {fileID: 439113855}
+  m_Layer: 0
+  m_Name: GrabVisualCueHorizontalTop
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &439113854
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 439113853}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.019199997, y: 0.1, z: -0.001}
+  m_LocalScale: {x: 0.074928366, y: 0.003631132, z: 0.009433999}
+  m_Children: []
+  m_Father: {fileID: 657254298}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &439113855
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 439113853}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 2
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 13a6bafb89ca6414895d965b2fdb2041, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &439113856
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 439113853}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &457644285
 GameObject:
   m_ObjectHideFlags: 0
@@ -1098,8 +1390,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Contents: {fileID: 50141923}
-  margin: 0.05
-  dist: 0.01
+  Specials: {fileID: 552499565}
 --- !u!114 &457644287
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1201,22 +1492,22 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.03
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.096
+      value: -0.14
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1226,7 +1517,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.5
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1236,12 +1527,12 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.5
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1251,7 +1542,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1270,7 +1561,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 50141924}
+    m_TransformParent: {fileID: 552499566}
     m_Modifications:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1280,62 +1571,77 @@ PrefabInstance:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 14
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.625
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.625
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.625
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.07399999
+      value: 0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.0196
+      value: -0.04
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.70659995
+      value: 0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1456,6 +1762,40 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 528106780}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &552499565
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 552499566}
+  m_Layer: 0
+  m_Name: Specials
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &552499566
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 552499565}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.018999998, y: -0.024600007, z: 0.22529998}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 267519455}
+  - {fileID: 484086144}
+  - {fileID: 1806167426}
+  - {fileID: 1305983241}
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &611283051
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1636,22 +1976,22 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.03
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.072
+      value: -0.12
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1661,7 +2001,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.5
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1671,12 +2011,12 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.5
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1686,7 +2026,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1706,6 +2046,42 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 648732645}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &657254297
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 657254298}
+  m_Layer: 0
+  m_Name: GravVisualCue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &657254298
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 657254297}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1905876310}
+  - {fileID: 1608379165}
+  - {fileID: 439113854}
+  - {fileID: 996425446}
+  - {fileID: 771260723}
+  - {fileID: 1409689315}
+  m_Father: {fileID: 102543591}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -1813,62 +2189,62 @@ PrefabInstance:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.012
+      value: -0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.024
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.03
+      value: -0.14
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1903,62 +2279,62 @@ PrefabInstance:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.012
+      value: 0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 100
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.03
+      value: -0.1
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1998,62 +2374,62 @@ PrefabInstance:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.012
+      value: -0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.03
+      value: -0.12
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2073,6 +2449,184 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 768812721}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &771260722
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 771260723}
+  - component: {fileID: 771260725}
+  - component: {fileID: 771260724}
+  m_Layer: 0
+  m_Name: GrabVisualCueHorizontalTop (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &771260723
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 771260722}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: -0.092, y: -0.0202, z: -0.001}
+  m_LocalScale: {x: 0.074928366, y: 0.003631132, z: 0.009433999}
+  m_Children: []
+  m_Father: {fileID: 657254298}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!23 &771260724
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 771260722}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 2
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 13a6bafb89ca6414895d965b2fdb2041, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &771260725
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 771260722}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &797501231
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 797501232}
+  - component: {fileID: 797501235}
+  - component: {fileID: 797501234}
+  - component: {fileID: 797501233}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &797501232
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 797501231}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1493125487}
+  m_Father: {fileID: 102543591}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0.07, y: -0.03}
+  m_SizeDelta: {x: 0.22, y: 0.02}
+  m_Pivot: {x: 0.5, y: -1}
+--- !u!114 &797501233
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 797501231}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &797501234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 797501231}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 1
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &797501235
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 797501231}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 963194227}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
 --- !u!1 &815432706
 GameObject:
   m_ObjectHideFlags: 0
@@ -2260,6 +2814,85 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
+--- !u!1 &996425445
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 996425446}
+  - component: {fileID: 996425448}
+  - component: {fileID: 996425447}
+  m_Layer: 0
+  m_Name: GrabVisualCueHorizontalBottom
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &996425446
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 996425445}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.0192, y: -0.13, z: -0.001}
+  m_LocalScale: {x: 0.074928366, y: 0.0036311317, z: 0.009433999}
+  m_Children: []
+  m_Father: {fileID: 657254298}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &996425447
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 996425445}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 2
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 13a6bafb89ca6414895d965b2fdb2041, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &996425448
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 996425445}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &1133846441
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2510,36 +3143,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1202680000}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1231922750
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1231922751}
-  m_Layer: 0
-  m_Name: Buttons
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1231922751
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1231922750}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 50141924}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1283710838
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2555,22 +3158,22 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.03
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.168
+      value: -0.2
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2580,7 +3183,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.5
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2590,12 +3193,12 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.5
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2605,7 +3208,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2624,7 +3227,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 50141924}
+    m_TransformParent: {fileID: 552499566}
     m_Modifications:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2634,62 +3237,77 @@ PrefabInstance:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 16
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.625
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.625
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.625
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.07399999
+      value: -0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.0996
+      value: -0.04
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.70659995
+      value: 0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2720,6 +3338,85 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1305983240}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1409689314
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1409689315}
+  - component: {fileID: 1409689317}
+  - component: {fileID: 1409689316}
+  m_Layer: 0
+  m_Name: GrabVisualCueHorizontalTop (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1409689315
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1409689314}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0.13, y: -0.0202, z: -0.001}
+  m_LocalScale: {x: 0.074928366, y: 0.003631132, z: 0.009433999}
+  m_Children: []
+  m_Father: {fileID: 657254298}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!23 &1409689316
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1409689314}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 2
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 13a6bafb89ca6414895d965b2fdb2041, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1409689317
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1409689314}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &1437543845
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2735,62 +3432,62 @@ PrefabInstance:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.012
+      value: -0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.048
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.03
+      value: -0.16
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2909,6 +3606,153 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!1 &1493125486
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1493125487}
+  - component: {fileID: 1493125490}
+  - component: {fileID: 1493125489}
+  - component: {fileID: 1493125488}
+  m_Layer: 5
+  m_Name: Text Field
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1493125487
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493125486}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 797501232}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.000000014901161, y: 0.000000007450581}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1493125488
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493125486}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad994c747a177f74a95313499e1d2e55, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1493125489
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493125486}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: fe0f56eb04ce8cb4cbd2844f88c8b1d5, type: 2}
+  m_sharedMaterial: {fileID: -3428160537946827419, guid: fe0f56eb04ce8cb4cbd2844f88c8b1d5,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 0.01
+  m_fontSizeBase: 0.01
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1493125490
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493125486}
+  m_CullTransparentMesh: 0
 --- !u!1001 &1512945311
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3164,6 +4008,85 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1586877550}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1608379164
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1608379165}
+  - component: {fileID: 1608379167}
+  - component: {fileID: 1608379166}
+  m_Layer: 0
+  m_Name: GrabVisualCueVerticalRight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1608379165
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1608379164}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.1075, y: -0.005, z: -0.001}
+  m_LocalScale: {x: 0.0034266084, y: 0.045, z: 0.0039000595}
+  m_Children: []
+  m_Father: {fileID: 657254298}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1608379166
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1608379164}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 2
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 15c4e4b880f2be34790dce1a74139d27, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1608379167
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1608379164}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &1608834605
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3334,6 +4257,257 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1636462261}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1695430390
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1695430391}
+  - component: {fileID: 1695430398}
+  - component: {fileID: 1695430397}
+  - component: {fileID: 1695430396}
+  - component: {fileID: 1695430395}
+  - component: {fileID: 1695430394}
+  - component: {fileID: 1695430393}
+  - component: {fileID: 1695430392}
+  m_Layer: 0
+  m_Name: Quad
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1695430391
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1695430390}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.0187, y: -0.0192, z: 0}
+  m_LocalScale: {x: 0.24, y: 0.26, z: 0.010599999}
+  m_Children: []
+  m_Father: {fileID: 2042680238}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1695430392
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1695430390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a98de877dee5fc341b4eb59dfdab266c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  autoConstraintSelection: 1
+  selectedConstraints: []
+--- !u!114 &1695430393
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1695430390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b3e6359c9750ad4fb8a05c9b8704d7b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  handType: 3
+  proximityType: 3
+  constraintOnRotation: 5
+  useLocalSpaceForConstraint: 0
+--- !u!114 &1695430394
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1695430390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 181cd563a8349c34ea8978b0bc8d9c7e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hostTransform: {fileID: 102543591}
+  manipulationType: 3
+  twoHandedManipulationType: 7
+  allowFarManipulation: 1
+  useForcesForNearManipulation: 0
+  oneHandRotationModeNear: 1
+  oneHandRotationModeFar: 1
+  releaseBehavior: 3
+  smoothingFar: 1
+  smoothingNear: 1
+  moveLerpTime: 0.001
+  rotateLerpTime: 0.001
+  scaleLerpTime: 0.001
+  enableConstraints: 1
+  constraintsManager: {fileID: 1695430392}
+  elasticsManager: {fileID: 0}
+  onManipulationStarted:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1695430397}
+        m_MethodName: set_material
+        m_Mode: 2
+        m_Arguments:
+          m_ObjectArgument: {fileID: 2100000, guid: 16526572b35ecaa4ba781a0bff18ab12,
+            type: 2}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Material, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 102543593}
+        m_MethodName: set_enabled
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 0}
+        m_MethodName: SetToggled
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: 102543592}
+        m_MethodName: PlayOneShot
+        m_Mode: 2
+        m_Arguments:
+          m_ObjectArgument: {fileID: 8300000, guid: 72d90092d0f1a734eb1cfcf71b8fa2e4,
+            type: 3}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.AudioClip, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+  onManipulationEnded:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1695430397}
+        m_MethodName: set_material
+        m_Mode: 2
+        m_Arguments:
+          m_ObjectArgument: {fileID: 2100000, guid: ec72a3a105768f746b556a8dfdae61a8,
+            type: 2}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Material, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 102543592}
+        m_MethodName: PlayOneShot
+        m_Mode: 2
+        m_Arguments:
+          m_ObjectArgument: {fileID: 8300000, guid: ec33d8a6027c1574390812966f8aef94,
+            type: 3}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.AudioClip, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  onHoverEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  onHoverExited:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1695430395
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1695430390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5afd5316c63705643b3daba5a6e923bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowTetherWhenManipulating: 1
+  IsBoundsHandles: 0
+--- !u!65 &1695430396
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1695430390}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.99999994, z: 1}
+  m_Center: {x: 0.00000004856583, y: 0, z: 3.0616168e-17}
+--- !u!23 &1695430397
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1695430390}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 2
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: ec72a3a105768f746b556a8dfdae61a8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1695430398
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1695430390}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &1744554898
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3450,22 +4624,22 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.03
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.144
+      value: -0.18
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -3475,7 +4649,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.5
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -3485,12 +4659,12 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.5
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -3500,7 +4674,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -3627,7 +4801,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 50141924}
+    m_TransformParent: {fileID: 552499566}
     m_Modifications:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -3637,62 +4811,77 @@ PrefabInstance:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.625
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.625
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.625
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.07399999
+      value: -0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.0596
+      value: -0.04
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.70659995
+      value: -0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -3723,6 +4912,85 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1806167425}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1905876309
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1905876310}
+  - component: {fileID: 1905876312}
+  - component: {fileID: 1905876311}
+  m_Layer: 0
+  m_Name: GrabVisualCueVerticalLeft
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1905876310
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1905876309}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.03571999, y: -0.005, z: -0.001}
+  m_LocalScale: {x: 0.0034266084, y: 0.045, z: 0.0039000595}
+  m_Children: []
+  m_Father: {fileID: 657254298}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1905876311
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1905876309}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 2
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 15c4e4b880f2be34790dce1a74139d27, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1905876312
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1905876309}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &1938142800
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3738,62 +5006,62 @@ PrefabInstance:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.012
+      value: -0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.072
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.03
+      value: -0.18
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071068
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -3993,6 +5261,37 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2019820280}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2042680237
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2042680238}
+  m_Layer: 0
+  m_Name: Backplate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2042680238
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2042680237}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.05, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 0.2, z: 1}
+  m_Children:
+  - {fileID: 1695430391}
+  m_Father: {fileID: 102543591}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &2088808315
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4008,22 +5307,22 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 0.01
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.03
+      value: -0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.12
+      value: -0.16
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -4033,7 +5332,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.5
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -4043,12 +5342,12 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.5
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -4058,7 +5357,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -5615,7 +6914,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &4669628314988621459
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Flick Keyboards/Assets/Scenes/Main.unity
+++ b/Flick Keyboards/Assets/Scenes/Main.unity
@@ -121,141 +121,62 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &23385020
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 23385021}
-  - component: {fileID: 23385023}
-  - component: {fileID: 23385022}
-  m_Layer: 0
-  m_Name: Quad
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &23385021
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 23385020}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.032, y: 0.032, z: 0.01}
-  m_Children: []
-  m_Father: {fileID: 1993739709}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &23385022
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 23385020}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 2
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 416caa6b57bb22c40ab9f1a4c12b304e, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &23385023
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 23385020}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1001 &24593521
+--- !u!1001 &13236766
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 737114949}
+    m_TransformParent: {fileID: 50141924}
     m_Modifications:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_Name
-      value: FlickButton (19)
+      value: FlickButton symbol
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 19
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.06
+      value: -0.012
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.06
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1
+      value: 0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -265,41 +186,30 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: useFlick
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: buttonName
-      value: 15
+      value: 10
       objectReference: {fileID: 0}
-    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: iconSet
-      value: 
-      objectReference: {fileID: 11400000, guid: 8b386ef895f7c924f8c4b03d1d3ed683,
-        type: 2}
     - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: iconQuadTexture
       value: 
-      objectReference: {fileID: 2800000, guid: ed2f699f32ec17f4cad3423d2c449119, type: 3}
+      objectReference: {fileID: 2800000, guid: a1edb550a4a681b479d98874d4ff0086, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!4 &24698675 stripped
+--- !u!4 &13236767 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
     type: 3}
-  m_PrefabInstance: {fileID: 1471222799}
+  m_PrefabInstance: {fileID: 13236766}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &50141923
 GameObject:
@@ -324,16 +234,29 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 50141923}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 1798666423}
+  - {fileID: 1231922751}
   - {fileID: 64373661}
+  - {fileID: 1779222319}
+  - {fileID: 2088808316}
   - {fileID: 2139273555}
-  - {fileID: 170361762}
-  m_Father: {fileID: 457644290}
-  m_RootOrder: 0
+  - {fileID: 648732646}
+  - {fileID: 255454565}
+  - {fileID: 1938142801}
+  - {fileID: 1437543846}
+  - {fileID: 712849016}
+  - {fileID: 751042341}
+  - {fileID: 768812722}
+  - {fileID: 13236767}
+  - {fileID: 267519455}
+  - {fileID: 484086144}
+  - {fileID: 1806167426}
+  - {fileID: 1305983241}
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &64373661 stripped
 Transform:
@@ -341,37 +264,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1283710838}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &93976614
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 93976615}
-  m_Layer: 0
-  m_Name: CompressableButtonVisuals
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &93976615
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 93976614}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.008}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1467809209}
-  m_Father: {fileID: 1488592802}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &101635057
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -472,12 +364,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
     type: 3}
   m_PrefabInstance: {fileID: 101635057}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &109559609 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 1623242766}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &117406338
 PrefabInstance:
@@ -729,300 +615,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 164518929}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &170361761
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 170361762}
-  - component: {fileID: 170361766}
-  - component: {fileID: 170361765}
-  - component: {fileID: 170361764}
-  - component: {fileID: 170361763}
-  m_Layer: 0
-  m_Name: NearMenu3x3 (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &170361762
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 170361761}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.019999996}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1488592802}
-  - {fileID: 532901724}
-  - {fileID: 737114949}
-  - {fileID: 2022473958}
-  - {fileID: 2109280971}
-  m_Father: {fileID: 50141924}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!82 &170361763
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 170361761}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!114 &170361764
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 170361761}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2d1fea68463e4e84b86c395b654f950d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  visualizationObject: {fileID: 0}
-  interactableObject: {fileID: 0}
-  autoFollowAtDistance: 0
-  autoFollowDistance: 2
-  autoFollowTransformTarget: {fileID: 0}
-  autoFollowTriggered:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &170361765
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 170361761}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4684083f6dff4a1d8a790bccc354fcf4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  updateLinkedTransform: 0
-  moveLerpTime: 0.5
-  rotateLerpTime: 0.5
-  scaleLerpTime: 0
-  maintainScaleOnInitialization: 1
-  smoothing: 1
-  lifetime: 0
-  referenceDirection: 1
-  minDistance: 0.3
-  maxDistance: 0.6
-  minViewDegrees: 0
-  maxViewDegrees: 20
-  aspectV: 1
-  ignoreAngleClamp: 0
-  ignoreDistanceClamp: 0
-  useFixedVerticalPosition: 1
-  fixedVerticalPosition: -0.4
-  orientToReferenceDirection: 0
---- !u!114 &170361766
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 170361761}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b55691ad5b034fe6966763a6e23818d2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  trackedTargetType: 0
-  trackedHandness: 3
-  trackedHandJoint: 2
-  transformOverride: {fileID: 0}
-  additionalOffset: {x: 0, y: 0, z: 0}
-  additionalRotation: {x: 0, y: 0, z: 0}
-  updateSolvers: 1
---- !u!1001 &192421585
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 737114949}
-    m_Modifications:
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Name
-      value: FlickButton (16)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 16
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.06
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.06
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: useFlick
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: buttonName
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: iconSet
-      value: 
-      objectReference: {fileID: 11400000, guid: 8b386ef895f7c924f8c4b03d1d3ed683,
-        type: 2}
-    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: iconQuadTexture
-      value: 
-      objectReference: {fileID: 2800000, guid: 8d0274d8bc6a17844a08b493920d9491, type: 3}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
 --- !u!1 &217987196
 GameObject:
   m_ObjectHideFlags: 0
@@ -1170,85 +762,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad994c747a177f74a95313499e1d2e55, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &245661782
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 245661783}
-  - component: {fileID: 245661785}
-  - component: {fileID: 245661784}
-  m_Layer: 0
-  m_Name: GrabVisualCueVerticalLeft
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &245661783
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 245661782}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.03571999, y: -0.005, z: -0.001}
-  m_LocalScale: {x: 0.0034266084, y: 0.045, z: 0.0039000595}
-  m_Children: []
-  m_Father: {fileID: 2022473958}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &245661784
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 245661782}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 2
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 15c4e4b880f2be34790dce1a74139d27, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &245661785
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 245661782}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &249057931
 GameObject:
   m_ObjectHideFlags: 0
@@ -1281,57 +794,62 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &257609483
+--- !u!1001 &255454564
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 737114949}
+    m_TransformParent: {fileID: 50141924}
     m_Modifications:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_Name
-      value: FlickButton (13)
+      value: FlickButton H
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.02
+      value: -0.012
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.02
+      value: -0.096
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1
+      value: 0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1341,12 +859,12 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1360,249 +878,68 @@ PrefabInstance:
       objectReference: {fileID: 2800000, guid: 7bd34b236cd238b42a79da1264e0a7bc, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!1 &260485434
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 260485435}
-  - component: {fileID: 260485439}
-  - component: {fileID: 260485438}
-  - component: {fileID: 260485437}
-  - component: {fileID: 260485436}
-  m_Layer: 0
-  m_Name: TextMeshPro
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &260485435
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 260485434}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 2123595059}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -0.0109}
-  m_SizeDelta: {x: 0.032, y: 0.01}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &260485436
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 260485434}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: Toggle
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 6a84f857bec7e7345843ae29404c57ce, type: 2}
-  m_sharedMaterial: {fileID: 21202819797275496, guid: 6a84f857bec7e7345843ae29404c57ce,
-    type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: 0
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 0.04
-  m_fontSizeBase: 0.04
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 514
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 0
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 1
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: -0.0022691963, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 260485439}
-  m_maskType: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
---- !u!222 &260485437
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 260485434}
-  m_CullTransparentMesh: 0
---- !u!33 &260485438
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 260485434}
-  m_Mesh: {fileID: 0}
---- !u!23 &260485439
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 260485434}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 4294967295
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 21202819797275496, guid: 6a84f857bec7e7345843ae29404c57ce, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!4 &294730061 stripped
+--- !u!4 &255454565 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
     type: 3}
-  m_PrefabInstance: {fileID: 858854402}
+  m_PrefabInstance: {fileID: 255454564}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &333528442
+--- !u!1001 &267519454
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 737114949}
+    m_TransformParent: {fileID: 50141924}
     m_Modifications:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_Name
-      value: FlickButton (11)
+      value: FlickButton delete
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.02
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.06
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1
+      value: 0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -1612,183 +949,42 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: useFlick
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: buttonName
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
+    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: iconSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 8b386ef895f7c924f8c4b03d1d3ed683,
+        type: 2}
     - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: iconQuadTexture
       value: 
-      objectReference: {fileID: 2800000, guid: d488d81be9447324ea02079efa6ef7c0, type: 3}
+      objectReference: {fileID: 2800000, guid: 8d0274d8bc6a17844a08b493920d9491, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!1 &348855750
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 348855751}
-  - component: {fileID: 348855753}
-  - component: {fileID: 348855752}
-  m_Layer: 0
-  m_Name: GrabVisualCueHorizontalTop
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &348855751
+--- !u!4 &267519455 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+    type: 3}
+  m_PrefabInstance: {fileID: 267519454}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 348855750}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.019199997, y: 0.1, z: -0.001}
-  m_LocalScale: {x: 0.074928366, y: 0.003631132, z: 0.009433999}
-  m_Children: []
-  m_Father: {fileID: 2022473958}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &348855752
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 348855750}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 2
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 13a6bafb89ca6414895d965b2fdb2041, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &348855753
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 348855750}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &370358071
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 370358072}
-  - component: {fileID: 370358074}
-  - component: {fileID: 370358073}
-  m_Layer: 5
-  m_Name: UIButtonSquareIcon
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &370358072
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 370358071}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.32, y: 0.32, z: 0.32}
-  m_Children: []
-  m_Father: {fileID: 2123595059}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &370358073
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 370358071}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 4294967295
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: fa419ab56051229449e3b813df8f295f, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &370358074
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 370358071}
-  m_Mesh: {fileID: 4300010, guid: b566bbce04d66f4428421e81a3af0299, type: 3}
 --- !u!1001 &419269803
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1902,6 +1098,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Contents: {fileID: 50141923}
+  margin: 0.05
+  dist: 0.01
 --- !u!114 &457644287
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1921,7 +1119,7 @@ MonoBehaviour:
   maintainScaleOnInitialization: 1
   smoothing: 1
   lifetime: 0
-  safeZone: 4
+  safeZone: 3
   safeZoneBuffer: 0.15
   updateWhenOppositeHandNear: 0
   hideHandCursorsOnActivate: 1
@@ -1955,7 +1153,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   trackedTargetType: 6
   trackedHandness: 1
-  trackedHandJoint: 2
+  trackedHandJoint: 1
   transformOverride: {fileID: 0}
   additionalOffset: {x: 0, y: 0, z: 0}
   additionalRotation: {x: 0, y: 0, z: 0}
@@ -1982,10 +1180,9 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 457644285}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.005, y: 0.02, z: -0.117}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 50141924}
+  m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1999,52 +1196,52 @@ PrefabInstance:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_Name
-      value: FlickButton (21)
+      value: FlickButton T
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.04
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.02
+      value: -0.096
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2054,7 +1251,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2068,117 +1265,107 @@ PrefabInstance:
       objectReference: {fileID: 2800000, guid: 14b119b5ac20c644ab8add294a748355, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!1 &469806657
-GameObject:
+--- !u!1001 &484086143
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 469806658}
-  - component: {fileID: 469806660}
-  - component: {fileID: 469806659}
-  m_Layer: 0
-  m_Name: Quad
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &469806658
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 50141924}
+    m_Modifications:
+    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_Name
+      value: FlickButton alldelete
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.07399999
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0196
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.70659995
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: useFlick
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: buttonName
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: iconSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 8b386ef895f7c924f8c4b03d1d3ed683,
+        type: 2}
+    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: iconQuadTexture
+      value: 
+      objectReference: {fileID: 2800000, guid: ea677436af9004848a7f20878e38257c, type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
+--- !u!4 &484086144 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+    type: 3}
+  m_PrefabInstance: {fileID: 484086143}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 469806657}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.032, y: 0.01, z: 0.01}
-  m_Children: []
-  m_Father: {fileID: 1443753485}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &469806659
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 469806657}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 2
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: ec72a3a105768f746b556a8dfdae61a8, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &469806660
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 469806657}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &523583080
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 523583081}
-  m_Layer: 5
-  m_Name: SeeItSayItLabel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &523583081
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 523583080}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.021, z: -0.009}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1809392172}
-  - {fileID: 1443753485}
-  m_Father: {fileID: 1488592802}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &528106780
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2269,37 +1456,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 528106780}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &532901723
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 532901724}
-  m_Layer: 0
-  m_Name: Backplate
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &532901724
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 532901723}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1746861160}
-  m_Father: {fileID: 170361762}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &611283051
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2465,6 +1621,91 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 638362404}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &648732645
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 50141924}
+    m_Modifications:
+    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_Name
+      value: FlickButton N
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.072
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: buttonName
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: iconQuadTexture
+      value: 
+      objectReference: {fileID: 2800000, guid: aa6158a278c13bb46b1c61b72c2f28f0, type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
+--- !u!4 &648732646 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+    type: 3}
+  m_PrefabInstance: {fileID: 648732645}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -2557,343 +1798,17 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!4 &710103509 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 192421585}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &737114948
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 737114949}
-  - component: {fileID: 737114950}
-  m_Layer: 0
-  m_Name: ButtonCollection
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &737114949
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 737114948}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.019, y: -0.0196, z: -1.0104}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 746089361}
-  - {fileID: 2010029459}
-  - {fileID: 1097729860}
-  - {fileID: 1143264189}
-  - {fileID: 1578277507}
-  - {fileID: 866017975}
-  - {fileID: 1316386959}
-  - {fileID: 1905017848}
-  - {fileID: 1548198156}
-  - {fileID: 1344396543}
-  - {fileID: 1342786975}
-  - {fileID: 1807085080}
-  - {fileID: 973093015}
-  - {fileID: 1400901030}
-  - {fileID: 109559609}
-  - {fileID: 973891445}
-  - {fileID: 710103509}
-  - {fileID: 294730061}
-  - {fileID: 24698675}
-  - {fileID: 743547533}
-  m_Father: {fileID: 170361762}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &737114950
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 737114948}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cf12ee76e7e00a44a9a84256760020e6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  nodeList:
-  - Name: FlickButton (4)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 1578277507}
-    Colliders: []
-  - Name: FlickButton (5)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 866017975}
-    Colliders: []
-  - Name: FlickButton (6)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 1316386959}
-    Colliders: []
-  - Name: FlickButton (7)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 1905017848}
-    Colliders: []
-  - Name: FlickButton (8)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 1548198156}
-    Colliders: []
-  - Name: FlickButton (9)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 1344396543}
-    Colliders: []
-  - Name: FlickButton (10)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 1342786975}
-    Colliders: []
-  - Name: FlickButton (11)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 1807085080}
-    Colliders: []
-  - Name: FlickButton (12)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 973093015}
-    Colliders: []
-  - Name: FlickButton (13)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 1400901030}
-    Colliders: []
-  - Name: FlickButton (14)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 109559609}
-    Colliders: []
-  - Name: FlickButton (15)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 973891445}
-    Colliders: []
-  - Name: FlickButton (16)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 710103509}
-    Colliders: []
-  - Name: FlickButton (17)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 294730061}
-    Colliders: []
-  - Name: FlickButton (18)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 24698675}
-    Colliders: []
-  - Name: FlickButton (19)
-    Offset: {x: 0, y: 0}
-    Radius: 0
-    Transform: {fileID: 743547533}
-    Colliders: []
-  ignoreInactiveTransforms: 1
-  sortType: 0
-  surfaceType: 1
-  orientType: 0
-  layout: 1
-  anchor: 4
-  anchorAlongAxis: 0
-  columnAlignment: 0
-  rowAlignment: 1
-  radius: 2
-  radialRange: 180
-  distance: 1
-  rows: 4
-  columns: 4
-  cellWidth: 0.04
-  cellHeight: 0.04
-  assetVersion: 1
---- !u!4 &743547533 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 24593521}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &746089361 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 791227461}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &787267323
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 787267324}
-  - component: {fileID: 787267327}
-  - component: {fileID: 787267326}
-  - component: {fileID: 787267325}
-  m_Layer: 5
-  m_Name: Text Field
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &787267324
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 787267323}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 2109280971}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.000000014901161, y: 0.000000007450581}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &787267325
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 787267323}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ad994c747a177f74a95313499e1d2e55, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &787267326
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 787267323}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: 
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: fe0f56eb04ce8cb4cbd2844f88c8b1d5, type: 2}
-  m_sharedMaterial: {fileID: -3428160537946827419, guid: fe0f56eb04ce8cb4cbd2844f88c8b1d5,
-    type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 0.01
-  m_fontSizeBase: 0.01
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &787267327
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 787267323}
-  m_CullTransparentMesh: 0
---- !u!1001 &791227461
+--- !u!1001 &712849015
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 737114949}
+    m_TransformParent: {fileID: 50141924}
     m_Modifications:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_Name
-      value: FlickButton
+      value: FlickButton R
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2903,42 +1818,42 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.08
+      value: -0.012
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.06
+      value: -0.024
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1
+      value: 0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -2948,66 +1863,87 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
+    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: buttonName
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: iconQuadTexture
+      value: 
+      objectReference: {fileID: 2800000, guid: 67c3d36f92fdd6c479cfe298ebb98aa4, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!1001 &804271425
+--- !u!4 &712849016 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+    type: 3}
+  m_PrefabInstance: {fileID: 712849015}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &751042340
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 737114949}
+    m_TransformParent: {fileID: 50141924}
     m_Modifications:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_Name
-      value: FlickButton (7)
+      value: FlickButton semi
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.06
+      value: 0.012
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.06
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1
+      value: 0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -3017,12 +1953,12 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -3041,6 +1977,102 @@ PrefabInstance:
       objectReference: {fileID: 2800000, guid: a5faffce34647cc4899607cb2c2f0e17, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
+--- !u!4 &751042341 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+    type: 3}
+  m_PrefabInstance: {fileID: 751042340}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &768812721
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 50141924}
+    m_Modifications:
+    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_Name
+      value: FlickButton W
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.012
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: buttonName
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: iconQuadTexture
+      value: 
+      objectReference: {fileID: 2800000, guid: d488d81be9447324ea02079efa6ef7c0, type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
+--- !u!4 &768812722 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+    type: 3}
+  m_PrefabInstance: {fileID: 768812721}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &815432706
 GameObject:
   m_ObjectHideFlags: 0
@@ -3085,357 +2117,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &847741234
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 737114949}
-    m_Modifications:
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Name
-      value: FlickButton (8)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.06
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: buttonName
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: iconQuadTexture
-      value: 
-      objectReference: {fileID: 2800000, guid: 044e3f1d7bedb544f83c1442f5915ebf, type: 3}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!1001 &858854402
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 737114949}
-    m_Modifications:
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Name
-      value: FlickButton (17)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 17
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.06
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: useFlick
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: buttonName
-      value: 13
-      objectReference: {fileID: 0}
-    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: iconSet
-      value: 
-      objectReference: {fileID: 11400000, guid: 8b386ef895f7c924f8c4b03d1d3ed683,
-        type: 2}
-    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: iconQuadTexture
-      value: 
-      objectReference: {fileID: 2800000, guid: ea677436af9004848a7f20878e38257c, type: 3}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!4 &866017975 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 1810390745}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &874454444
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 874454448}
-  - component: {fileID: 874454447}
-  - component: {fileID: 874454445}
-  - component: {fileID: 874454446}
-  m_Layer: 0
-  m_Name: HighlightPlate
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!23 &874454445
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 874454444}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 2
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 329cdefad4cf0f14e9b6767d0af094b0, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!114 &874454446
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 874454444}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 36065390e01a3cd40b87e4bf4acd02f9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!33 &874454447
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 874454444}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &874454448
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 874454444}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1467809209}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &907907108
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 907907109}
-  - component: {fileID: 907907111}
-  - component: {fileID: 907907110}
-  m_Layer: 0
-  m_Name: GrabVisualCueHorizontalTop (2)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &907907109
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 907907108}
-  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: 0.13, y: -0.0202, z: -0.001}
-  m_LocalScale: {x: 0.074928366, y: 0.003631132, z: 0.009433999}
-  m_Children: []
-  m_Father: {fileID: 2022473958}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
---- !u!23 &907907110
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 907907108}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 2
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 13a6bafb89ca6414895d965b2fdb2041, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &907907111
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 907907108}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -3579,103 +2260,6 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
---- !u!4 &973093015 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 1813366348}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &973891445 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 1285393111}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &979181432
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 979181433}
-  - component: {fileID: 979181435}
-  - component: {fileID: 979181434}
-  m_Layer: 0
-  m_Name: GrabVisualCueHorizontalTop (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &979181433
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 979181432}
-  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: -0.092, y: -0.0202, z: -0.001}
-  m_LocalScale: {x: 0.074928366, y: 0.003631132, z: 0.009433999}
-  m_Children: []
-  m_Father: {fileID: 2022473958}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
---- !u!23 &979181434
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 979181432}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 2
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 13a6bafb89ca6414895d965b2fdb2041, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &979181435
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 979181432}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1097729860 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 1799367074}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1133846441
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3756,91 +2340,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1133846441}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &1143264189 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 1818786886}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1181767338
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1181767339}
-  - component: {fileID: 1181767341}
-  - component: {fileID: 1181767340}
-  m_Layer: 0
-  m_Name: Quad
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1181767339
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1181767338}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.032, y: 0.032, z: 0.01}
-  m_Children: []
-  m_Father: {fileID: 1621953169}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &1181767340
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1181767338}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 2
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 552f1a3245d3edc4a96fe296c950532a, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1181767341
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1181767338}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &1191166200
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4011,7 +2510,7 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1202680000}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1222826646
+--- !u!1 &1231922750
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4019,183 +2518,28 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1222826647}
-  - component: {fileID: 1222826651}
-  - component: {fileID: 1222826650}
-  - component: {fileID: 1222826649}
-  - component: {fileID: 1222826648}
+  - component: {fileID: 1231922751}
   m_Layer: 0
-  m_Name: UIButtonCharIcon
+  m_Name: Buttons
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &1222826647
-RectTransform:
+  m_IsActive: 1
+--- !u!4 &1231922751
+Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1222826646}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_GameObject: {fileID: 1231922750}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 2123595059}
-  m_RootOrder: 2
+  m_Father: {fileID: 50141924}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0.015, y: 0.015}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1222826648
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1222826646}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: "\uEBD2"
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 0}
-  m_sharedMaterial: {fileID: 0}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: 0
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 0.115
-  m_fontSizeBase: 0.1
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 544
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 0
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 1
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 1222826651}
-  m_maskType: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
---- !u!222 &1222826649
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1222826646}
-  m_CullTransparentMesh: 0
---- !u!33 &1222826650
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1222826646}
-  m_Mesh: {fileID: 0}
---- !u!23 &1222826651
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1222826646}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 4294967295
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
 --- !u!1001 &1283710838
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4206,7 +2550,7 @@ PrefabInstance:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_Name
-      value: FlickButton (20)
+      value: FlickButton A
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -4221,37 +2565,37 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.02
+      value: -0.168
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -4261,7 +2605,7 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -4275,57 +2619,62 @@ PrefabInstance:
       objectReference: {fileID: 2800000, guid: 061751d207b2779489f803584403c06f, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!1001 &1285393111
+--- !u!1001 &1305983240
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 737114949}
+    m_TransformParent: {fileID: 50141924}
     m_Modifications:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_Name
-      value: FlickButton (15)
+      value: FlickButton search
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.02
+      value: 0.07399999
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.06
+      value: -0.0996
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1
+      value: 0.70659995
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -4335,80 +2684,132 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: useFlick
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: buttonName
-      value: 10
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: iconSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 8b386ef895f7c924f8c4b03d1d3ed683,
+        type: 2}
+    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: iconQuadTexture
+      value: 
+      objectReference: {fileID: 2800000, guid: ed2f699f32ec17f4cad3423d2c449119, type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
+--- !u!4 &1305983241 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+    type: 3}
+  m_PrefabInstance: {fileID: 1305983240}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1437543845
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 50141924}
+    m_Modifications:
+    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_Name
+      value: FlickButton Y
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.012
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.048
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: buttonName
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: iconQuadTexture
       value: 
-      objectReference: {fileID: 2800000, guid: a1edb550a4a681b479d98874d4ff0086, type: 3}
+      objectReference: {fileID: 2800000, guid: b075c960857a3194d8f8a62521bd6203, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!4 &1316386959 stripped
+--- !u!4 &1437543846 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
     type: 3}
-  m_PrefabInstance: {fileID: 2050573815}
+  m_PrefabInstance: {fileID: 1437543845}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &1342786975 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 1484820395}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1344396543 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 1545160177}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1400901030 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 257609483}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1443753484
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1443753485}
-  m_Layer: 0
-  m_Name: LabelPlate
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1443753485
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1443753484}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 469806658}
-  m_Father: {fileID: 523583081}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1456497890
 GameObject:
   m_ObjectHideFlags: 0
@@ -4508,739 +2909,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!1 &1467809208
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1467809209}
-  - component: {fileID: 1467809212}
-  - component: {fileID: 1467809211}
-  - component: {fileID: 1467809210}
-  m_Layer: 0
-  m_Name: FrontPlate
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1467809209
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1467809208}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.008}
-  m_LocalScale: {x: 0.032, y: 0.032, z: 0.016}
-  m_Children:
-  - {fileID: 874454448}
-  m_Father: {fileID: 93976615}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1467809210
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1467809208}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 36065390e01a3cd40b87e4bf4acd02f9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1467809211
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1467809208}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 4294967295
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 38a587e9218b3284485088c9925af61f, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 1
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1467809212
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1467809208}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1001 &1471222799
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 737114949}
-    m_Modifications:
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Name
-      value: FlickButton (18)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 18
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.06
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: useFlick
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: buttonName
-      value: 14
-      objectReference: {fileID: 0}
-    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: iconSet
-      value: 
-      objectReference: {fileID: 11400000, guid: 8b386ef895f7c924f8c4b03d1d3ed683,
-        type: 2}
-    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: iconQuadTexture
-      value: 
-      objectReference: {fileID: 2800000, guid: d74cdc58c5d172a469ea5ca987eb17f6, type: 3}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!1001 &1484820395
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 737114949}
-    m_Modifications:
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Name
-      value: FlickButton (10)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: buttonName
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: iconQuadTexture
-      value: 
-      objectReference: {fileID: 2800000, guid: b075c960857a3194d8f8a62521bd6203, type: 3}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!1 &1488592794
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1488592802}
-  - component: {fileID: 1488592801}
-  - component: {fileID: 1488592796}
-  - component: {fileID: 1488592798}
-  - component: {fileID: 1488592795}
-  - component: {fileID: 1488592797}
-  - component: {fileID: 1488592800}
-  - component: {fileID: 1488592799}
-  m_Layer: 0
-  m_Name: ButtonPin
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1488592795
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1488592794}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1410eac1ae94b4d4492a09cc368e152c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  states: {fileID: 11400000, guid: e51893c8eb7938e4ba43985af43c0f72, type: 2}
-  InputActionId: 0
-  isGlobal: 0
-  Dimensions: 2
-  dimensionIndex: 0
-  startDimensionIndex: 1
-  CanSelect: 1
-  CanDeselect: 1
-  VoiceCommand: Select
-  voiceRequiresFocus: 1
-  profiles:
-  - Target: {fileID: 523583080}
-    Themes:
-    - {fileID: 11400000, guid: 0c4c73f326f602744bdcfff481fd6f20, type: 2}
-    - {fileID: 11400000, guid: 0c4c73f326f602744bdcfff481fd6f20, type: 2}
-  - Target: {fileID: 1467809208}
-    Themes:
-    - {fileID: 11400000, guid: 8f8cfb3041153fa45bccb6d664a563ec, type: 2}
-    - {fileID: 11400000, guid: 8f8cfb3041153fa45bccb6d664a563ec, type: 2}
-  - Target: {fileID: 1621953168}
-    Themes:
-    - {fileID: 11400000, guid: 452ab0b768e73aa45a65adeb08147cec, type: 2}
-    - {fileID: 11400000, guid: c020ebf06513a084caa57aa68a245a6b, type: 2}
-  OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 170361764}
-        m_MethodName: ToggleFollowMeBehavior
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  Events:
-  - Event:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 1488592796}
-          m_MethodName: AnimateInHighlightPlate
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
-    ClassName: InteractableOnFocusReceiver
-    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.UI.InteractableOnFocusReceiver,
-      Microsoft.MixedReality.Toolkit.SDK
-    Settings:
-    - Type: 18
-      Label: On Focus Off
-      Name: OnFocusOff
-      Tooltip: Focus has left the object
-      IntValue: 0
-      StringValue: 
-      FloatValue: 0
-      BoolValue: 0
-      GameObjectValue: {fileID: 0}
-      ScriptableObjectValue: {fileID: 0}
-      ObjectValue: {fileID: 0}
-      MaterialValue: {fileID: 0}
-      TextureValue: {fileID: 0}
-      ColorValue: {r: 0, g: 0, b: 0, a: 0}
-      Vector2Value: {x: 0, y: 0}
-      Vector3Value: {x: 0, y: 0, z: 0}
-      Vector4Value: {x: 0, y: 0, z: 0, w: 0}
-      CurveValue:
-        serializedVersion: 2
-        m_Curve: []
-        m_PreInfinity: 0
-        m_PostInfinity: 0
-        m_RotationOrder: 0
-      AudioClipValue: {fileID: 0}
-      QuaternionValue: {x: 0, y: 0, z: 0, w: 0}
-      EventValue:
-        m_PersistentCalls:
-          m_Calls:
-          - m_Target: {fileID: 1488592796}
-            m_MethodName: AnimateOutHighlightPlate
-            m_Mode: 1
-            m_Arguments:
-              m_ObjectArgument: {fileID: 0}
-              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-              m_IntArgument: 0
-              m_FloatArgument: 0
-              m_StringArgument: 
-              m_BoolArgument: 0
-            m_CallState: 2
-      Options: []
-  - Event:
-      m_PersistentCalls:
-        m_Calls: []
-    ClassName: InteractableOnToggleReceiver
-    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.UI.InteractableOnToggleReceiver,
-      Microsoft.MixedReality.Toolkit.SDK
-    Settings:
-    - Type: 18
-      Label: On Deselect
-      Name: OnDeselect
-      Tooltip: The toggle is deselected
-      IntValue: 0
-      StringValue: 
-      FloatValue: 0
-      BoolValue: 0
-      GameObjectValue: {fileID: 0}
-      ScriptableObjectValue: {fileID: 0}
-      ObjectValue: {fileID: 0}
-      MaterialValue: {fileID: 0}
-      TextureValue: {fileID: 0}
-      ColorValue: {r: 0, g: 0, b: 0, a: 0}
-      Vector2Value: {x: 0, y: 0}
-      Vector3Value: {x: 0, y: 0, z: 0}
-      Vector4Value: {x: 0, y: 0, z: 0, w: 0}
-      CurveValue:
-        serializedVersion: 2
-        m_Curve: []
-        m_PreInfinity: 0
-        m_PostInfinity: 0
-        m_RotationOrder: 0
-      AudioClipValue: {fileID: 0}
-      QuaternionValue: {x: 0, y: 0, z: 0, w: 0}
-      EventValue:
-        m_PersistentCalls:
-          m_Calls: []
-      Options: []
-  resetOnDestroy: 0
-  enabledOnStart: 1
---- !u!114 &1488592796
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1488592794}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f98e7663599230e419addf153615c144, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  movingButtonVisuals: {fileID: 2096041537}
-  distanceSpaceMode: 1
-  startPushDistance: -0.008
-  maxPushDistance: 0.006
-  pressDistance: 0.0005
-  releaseDistanceDelta: 0.002
-  returnSpeed: 25
-  releaseOnTouchEnd: 1
-  enforceFrontPush: 1
-  TouchBegin:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1488592798}
-        m_MethodName: OnHandPressTouched
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  TouchEnd:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1488592798}
-        m_MethodName: OnHandPressUntouched
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  ButtonPressed:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1488592798}
-        m_MethodName: OnHandPressTriggered
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1488592797}
-        m_MethodName: PlayOneShot
-        m_Mode: 2
-        m_Arguments:
-          m_ObjectArgument: {fileID: 8300000, guid: 291bf9326e517b0489c2ee53d0a6a63f,
-            type: 3}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.AudioClip, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  ButtonReleased:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1488592798}
-        m_MethodName: OnHandPressCompleted
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1488592797}
-        m_MethodName: PlayOneShot
-        m_Mode: 2
-        m_Arguments:
-          m_ObjectArgument: {fileID: 8300000, guid: 40ae713ddf420714bbc1a3b5c3f2eac1,
-            type: 3}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.AudioClip, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  movingButtonIconText: {fileID: 2123595058}
-  compressableButtonVisuals: {fileID: 93976614}
-  minCompressPercentage: 0.25
-  highlightPlate: {fileID: 874454445}
-  highlightPlateAnimationTime: 0.25
---- !u!82 &1488592797
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1488592794}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!114 &1488592798
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1488592794}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 881d1ff8f009f5148b9f192e6ba31223, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  routingTarget: {fileID: 1488592795}
-  InteractableOnClick: 1
---- !u!114 &1488592799
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1488592794}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2cf098d972aeb8b4daa70b00381af006, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  mainLabelText: {fileID: 260485436}
-  interactable: {fileID: 1488592795}
-  seeItSayItLabel: {fileID: 523583080}
-  seeItSayItLabelText: {fileID: 1809392173}
-  iconStyle: 0
-  iconCharLabel: {fileID: 1222826648}
-  iconCharFont: {fileID: 0}
-  iconChar: 0
-  iconSpriteRenderer: {fileID: 1881705091}
-  iconSprite: {fileID: 21300000, guid: 20f25674b9512834f88938d45ed495d7, type: 3}
-  iconQuadRenderer: {fileID: 370358073}
-  iconQuadTextureNameID: _MainTex
-  iconQuadTexture: {fileID: 2800000, guid: 5ced9c7e98be2e941a88b5d0a16b2a3b, type: 3}
-  defaultButtonQuadMaterial: {fileID: 2100000, guid: fa419ab56051229449e3b813df8f295f,
-    type: 2}
-  iconSet: {fileID: 11400000, guid: 8b386ef895f7c924f8c4b03d1d3ed683, type: 2}
-  defaultIconSet: {fileID: 11400000, guid: 8b386ef895f7c924f8c4b03d1d3ed683, type: 2}
---- !u!114 &1488592800
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1488592794}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 98c748f3768ab714a8449b60fb9edc5c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  eventsToReceive: 0
-  debounceThreshold: 0.01
-  localForward: {x: 0, y: 0, z: -1}
-  localUp: {x: 0, y: 1, z: 0}
-  localCenter: {x: 0, y: 0, z: -0.008}
-  bounds: {x: 0.032, y: 0.032}
-  touchableCollider: {fileID: 1488592801}
---- !u!65 &1488592801
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1488592794}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.032, y: 0.032, z: 0.016}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!4 &1488592802
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1488592794}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.1623, y: 0.0328, z: -0.0082}
-  m_LocalScale: {x: 0.8, y: 0.8, z: 1}
-  m_Children:
-  - {fileID: 2096041538}
-  - {fileID: 93976615}
-  - {fileID: 523583081}
-  - {fileID: 1993739709}
-  - {fileID: 2123595059}
-  - {fileID: 1621953169}
-  m_Father: {fileID: 170361762}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1512945311
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5411,116 +3079,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1514087804}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1545160177
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 737114949}
-    m_Modifications:
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Name
-      value: FlickButton (9)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: buttonName
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: iconQuadTexture
-      value: 
-      objectReference: {fileID: 2800000, guid: aa6158a278c13bb46b1c61b72c2f28f0, type: 3}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!4 &1548198156 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 847741234}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1578277506 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 1643083144}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1578277507 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 1643083144}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1578277508
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1578277506}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: de684339eac1cd94e8f5f2810cdc972b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  hintBoxesPrefab: {fileID: 0}
 --- !u!1001 &1586877550
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5691,116 +3249,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1608834605}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1621953168
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1621953169}
-  m_Layer: 0
-  m_Name: BackPlateToggleState
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &1621953169
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1621953168}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.0075}
-  m_LocalScale: {x: 0.88717437, y: 0.88717437, z: 0.88717437}
-  m_Children:
-  - {fileID: 1181767339}
-  m_Father: {fileID: 1488592802}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1623242766
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 737114949}
-    m_Modifications:
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Name
-      value: FlickButton (14)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 14
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: buttonName
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: iconQuadTexture
-      value: 
-      objectReference: {fileID: 2800000, guid: 67c3d36f92fdd6c479cfe298ebb98aa4, type: 3}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
 --- !u!1001 &1636462261
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5886,95 +3334,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1636462261}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1643083144
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 737114949}
-    m_Modifications:
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Name
-      value: FlickButton (4)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.06
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.06
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1586041479065354838, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4201759644772353463, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5638165271242205445, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: keyInput
-      value: 
-      objectReference: {fileID: 787267325}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
 --- !u!1001 &1744554898
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6076,257 +3435,91 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1744554898}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1746861159
-GameObject:
+--- !u!1001 &1779222318
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1746861160}
-  - component: {fileID: 1746861167}
-  - component: {fileID: 1746861166}
-  - component: {fileID: 1746861165}
-  - component: {fileID: 1746861164}
-  - component: {fileID: 1746861163}
-  - component: {fileID: 1746861162}
-  - component: {fileID: 1746861161}
-  m_Layer: 0
-  m_Name: Quad
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1746861160
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1746861159}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.0187, y: -0.0192, z: 0}
-  m_LocalScale: {x: 0.24, y: 0.26, z: 0.010599999}
-  m_Children: []
-  m_Father: {fileID: 532901724}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1746861161
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1746861159}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a98de877dee5fc341b4eb59dfdab266c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  autoConstraintSelection: 1
-  selectedConstraints: []
---- !u!114 &1746861162
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1746861159}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5b3e6359c9750ad4fb8a05c9b8704d7b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  handType: 3
-  proximityType: 3
-  constraintOnRotation: 5
-  useLocalSpaceForConstraint: 0
---- !u!114 &1746861163
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1746861159}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 181cd563a8349c34ea8978b0bc8d9c7e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  hostTransform: {fileID: 170361762}
-  manipulationType: 3
-  twoHandedManipulationType: 7
-  allowFarManipulation: 1
-  useForcesForNearManipulation: 0
-  oneHandRotationModeNear: 1
-  oneHandRotationModeFar: 1
-  releaseBehavior: 3
-  smoothingFar: 1
-  smoothingNear: 1
-  moveLerpTime: 0.001
-  rotateLerpTime: 0.001
-  scaleLerpTime: 0.001
-  enableConstraints: 1
-  constraintsManager: {fileID: 1746861161}
-  elasticsManager: {fileID: 0}
-  onManipulationStarted:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1746861166}
-        m_MethodName: set_material
-        m_Mode: 2
-        m_Arguments:
-          m_ObjectArgument: {fileID: 2100000, guid: 16526572b35ecaa4ba781a0bff18ab12,
-            type: 2}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Material, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 170361765}
-        m_MethodName: set_enabled
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1488592795}
-        m_MethodName: SetToggled
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 170361763}
-        m_MethodName: PlayOneShot
-        m_Mode: 2
-        m_Arguments:
-          m_ObjectArgument: {fileID: 8300000, guid: 72d90092d0f1a734eb1cfcf71b8fa2e4,
-            type: 3}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.AudioClip, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-  onManipulationEnded:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1746861166}
-        m_MethodName: set_material
-        m_Mode: 2
-        m_Arguments:
-          m_ObjectArgument: {fileID: 2100000, guid: ec72a3a105768f746b556a8dfdae61a8,
-            type: 2}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Material, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 170361763}
-        m_MethodName: PlayOneShot
-        m_Mode: 2
-        m_Arguments:
-          m_ObjectArgument: {fileID: 8300000, guid: ec33d8a6027c1574390812966f8aef94,
-            type: 3}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.AudioClip, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  onHoverEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  onHoverExited:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &1746861164
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1746861159}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5afd5316c63705643b3daba5a6e923bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ShowTetherWhenManipulating: 1
-  IsBoundsHandles: 0
---- !u!65 &1746861165
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1746861159}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 0.99999994, z: 1}
-  m_Center: {x: 0.00000004856583, y: 0, z: 3.0616168e-17}
---- !u!23 &1746861166
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_Modification:
+    m_TransformParent: {fileID: 50141924}
+    m_Modifications:
+    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_Name
+      value: FlickButton K
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.144
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: buttonName
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: iconQuadTexture
+      value: 
+      objectReference: {fileID: 2800000, guid: 044e3f1d7bedb544f83c1442f5915ebf, type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
+--- !u!4 &1779222319 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+    type: 3}
+  m_PrefabInstance: {fileID: 1779222318}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1746861159}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 2
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: ec72a3a105768f746b556a8dfdae61a8, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1746861167
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1746861159}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &1779998482
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6423,114 +3616,23 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1779998482}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &1798666423 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 1808782798}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1799367074
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 737114949}
-    m_Modifications:
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Name
-      value: FlickButton (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.08
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
 --- !u!4 &1802428042 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
     type: 3}
   m_PrefabInstance: {fileID: 1940064039}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &1807085080 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 333528442}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1808782798
+--- !u!1001 &1806167425
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 50141924}
     m_Modifications:
-    - target: {fileID: 1312930847085162432, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Center.z
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_Name
-      value: FlickButton (4)
+      value: FlickButton space
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -6540,42 +3642,42 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 0.07399999
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.0596
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.019999996
+      value: 0.70659995
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -6585,619 +3687,132 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1586041479065354838, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4201759644772353463, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5638165271242205445, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
-      propertyPath: keyInput
-      value: 
-      objectReference: {fileID: 217987200}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!1 &1809392171
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1809392172}
-  - component: {fileID: 1809392176}
-  - component: {fileID: 1809392175}
-  - component: {fileID: 1809392174}
-  - component: {fileID: 1809392173}
-  m_Layer: 0
-  m_Name: TextMeshPro
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1809392172
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1809392171}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.001}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 523583081}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0.032, y: 0.01}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1809392173
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1809392171}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: Say "Button"
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 6a84f857bec7e7345843ae29404c57ce, type: 2}
-  m_sharedMaterial: {fileID: 21202819797275496, guid: 6a84f857bec7e7345843ae29404c57ce,
-    type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: 0
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 0.04
-  m_fontSizeBase: 0.04
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 514
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 0
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 1
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 1809392176}
-  m_maskType: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
---- !u!222 &1809392174
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1809392171}
-  m_CullTransparentMesh: 0
---- !u!33 &1809392175
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1809392171}
-  m_Mesh: {fileID: 0}
---- !u!23 &1809392176
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1809392171}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 4294967295
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 21202819797275496, guid: 6a84f857bec7e7345843ae29404c57ce, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!1001 &1810390745
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 737114949}
-    m_Modifications:
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Name
-      value: FlickButton (5)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.06
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
+      propertyPath: useFlick
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: buttonName
-      value: 3
+      value: 14
       objectReference: {fileID: 0}
+    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: iconSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 8b386ef895f7c924f8c4b03d1d3ed683,
+        type: 2}
     - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: iconQuadTexture
       value: 
-      objectReference: {fileID: 2800000, guid: 14b119b5ac20c644ab8add294a748355, type: 3}
+      objectReference: {fileID: 2800000, guid: d74cdc58c5d172a469ea5ca987eb17f6, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!1001 &1813366348
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 737114949}
-    m_Modifications:
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Name
-      value: FlickButton (12)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.06
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: buttonName
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: iconQuadTexture
-      value: 
-      objectReference: {fileID: 2800000, guid: b87e9192cfff21249b87416750a83ba2, type: 3}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!1001 &1818786886
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 737114949}
-    m_Modifications:
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Name
-      value: FlickButton (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.08
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.06
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!1 &1881705089
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1881705090}
-  - component: {fileID: 1881705091}
-  m_Layer: 0
-  m_Name: UIButtonSpriteIcon
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &1881705090
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1881705089}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.0025, y: 0.0025, z: 0.0025}
-  m_Children: []
-  m_Father: {fileID: 2123595059}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1881705091
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1881705089}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 6a6e5414f9c66aa4a8c85eb38302a558, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 2.56, y: 2.56}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &1905017848 stripped
+--- !u!4 &1806167426 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
     type: 3}
-  m_PrefabInstance: {fileID: 804271425}
+  m_PrefabInstance: {fileID: 1806167425}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1918111319
-GameObject:
+--- !u!1001 &1938142800
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1918111320}
-  - component: {fileID: 1918111322}
-  - component: {fileID: 1918111321}
-  m_Layer: 0
-  m_Name: GrabVisualCueHorizontalBottom
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1918111320
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 50141924}
+    m_Modifications:
+    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_Name
+      value: FlickButton M
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.012
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.072
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: buttonName
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
+        type: 3}
+      propertyPath: iconQuadTexture
+      value: 
+      objectReference: {fileID: 2800000, guid: 8cd18d3d9e6cbf54dae2b5fe2c7d935b, type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
+--- !u!4 &1938142801 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+    type: 3}
+  m_PrefabInstance: {fileID: 1938142800}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1918111319}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.0192, y: -0.13, z: -0.001}
-  m_LocalScale: {x: 0.074928366, y: 0.0036311317, z: 0.009433999}
-  m_Children: []
-  m_Father: {fileID: 2022473958}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &1918111321
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1918111319}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 2
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 13a6bafb89ca6414895d965b2fdb2041, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1918111322
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1918111319}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &1940064039
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7277,43 +3892,6 @@ PrefabInstance:
       objectReference: {fileID: 2800000, guid: 061751d207b2779489f803584403c06f, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!1 &1993739708
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1993739709}
-  m_Layer: 0
-  m_Name: BackPlate
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1993739709
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1993739708}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.008}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 23385021}
-  m_Father: {fileID: 1488592802}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &2010029459 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-    type: 3}
-  m_PrefabInstance: {fileID: 2120560182}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2019820280
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7415,98 +3993,62 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2019820280}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &2022473957
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2022473958}
-  m_Layer: 0
-  m_Name: GravVisualCue
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2022473958
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2022473957}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 245661783}
-  - {fileID: 2133498236}
-  - {fileID: 348855751}
-  - {fileID: 1918111320}
-  - {fileID: 979181433}
-  - {fileID: 907907109}
-  m_Father: {fileID: 170361762}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &2050573815
+--- !u!1001 &2088808315
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 737114949}
+    m_TransformParent: {fileID: 50141924}
     m_Modifications:
     - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_Name
-      value: FlickButton (6)
+      value: FlickButton S
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.06
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.02
+      value: 0.03
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1
+      value: -0.12
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
@@ -7516,336 +4058,26 @@ PrefabInstance:
     - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 5662465999127826701, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: buttonName
-      value: 6
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8649941150016685541, guid: c45c5ed467df77345b84acf836ef1779,
         type: 3}
       propertyPath: iconQuadTexture
       value: 
-      objectReference: {fileID: 2800000, guid: 8cd18d3d9e6cbf54dae2b5fe2c7d935b, type: 3}
+      objectReference: {fileID: 2800000, guid: b87e9192cfff21249b87416750a83ba2, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!1 &2096041537
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2096041538}
-  m_Layer: 0
-  m_Name: ButtonContent
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2096041538
+--- !u!4 &2088808316 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
+    type: 3}
+  m_PrefabInstance: {fileID: 2088808315}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2096041537}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1488592802}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2109280970
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2109280971}
-  - component: {fileID: 2109280974}
-  - component: {fileID: 2109280973}
-  - component: {fileID: 2109280972}
-  m_Layer: 5
-  m_Name: Canvas
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &2109280971
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2109280970}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 787267324}
-  m_Father: {fileID: 170361762}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0.0188, y: 0.0604}
-  m_SizeDelta: {x: 0.2, y: 0.02}
-  m_Pivot: {x: 0.5, y: -1}
---- !u!114 &2109280972
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2109280970}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
---- !u!114 &2109280973
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2109280970}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 1
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
---- !u!223 &2109280974
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2109280970}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 2
-  m_Camera: {fileID: 963194227}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 25
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!1001 &2120560182
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 737114949}
-    m_Modifications:
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_Name
-      value: FlickButton (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847085162460, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.08
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c45c5ed467df77345b84acf836ef1779, type: 3}
---- !u!1 &2123595058
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2123595059}
-  m_Layer: 0
-  m_Name: IconAndText
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2123595059
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2123595058}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.0704, y: 0.0631, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 260485435}
-  - {fileID: 370358072}
-  - {fileID: 1222826647}
-  - {fileID: 1881705090}
-  m_Father: {fileID: 1488592802}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2133498235
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2133498236}
-  - component: {fileID: 2133498238}
-  - component: {fileID: 2133498237}
-  m_Layer: 0
-  m_Name: GrabVisualCueVerticalRight
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2133498236
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2133498235}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.1075, y: -0.005, z: -0.001}
-  m_LocalScale: {x: 0.0034266084, y: 0.045, z: 0.0039000595}
-  m_Children: []
-  m_Father: {fileID: 2022473958}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &2133498237
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2133498235}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 2
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 15c4e4b880f2be34790dce1a74139d27, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &2133498238
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2133498235}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!4 &2139273555 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1312930847604730173, guid: c45c5ed467df77345b84acf836ef1779,

--- a/Flick Keyboards/Assets/Scripts/HandPosition.cs
+++ b/Flick Keyboards/Assets/Scripts/HandPosition.cs
@@ -10,11 +10,8 @@ using Microsoft.MixedReality.Toolkit;
 public class HandPosition : MonoBehaviour
 {
     [SerializeField] GameObject Contents;
-    [SerializeField] float margin;
-    [SerializeField] float dist;
+    [SerializeField] GameObject Specials;
     private Vector3 _estimatedAngularVelocity = Vector3.zero;
-    private Vector3 shaftPosition;
-    private Quaternion shaftRotation;
     private Quaternion pastRotation = Quaternion.identity;
     public Vector3 EstimatedAngularVelocity
     {
@@ -25,70 +22,61 @@ public class HandPosition : MonoBehaviour
     void Start()
     {
         Contents.SetActive(false);
+        Specials.SetActive(false);
     }
 
     // Update is called once per frame
     void Update()
     {
         var handJointService = CoreServices.GetInputSystemDataProvider<IMixedRealityHandJointService>();
-        if(HandJointUtils.TryGetJointPose(TrackedHandJoint.Palm, Handedness.Left, out MixedRealityPose pose))
+        if(HandJointUtils.TryGetJointPose(TrackedHandJoint.Palm, Handedness.Left, out MixedRealityPose lpose))
         {
             Contents.SetActive(true);
+            Specials.SetActive(true);
             Transform jointTransform = handJointService.RequestJointTransform(TrackedHandJoint.Wrist, Handedness.Left);
-            shaftPosition = jointTransform.position + jointTransform.forward * (-dist);
-            shaftRotation = jointTransform.rotation;
-            // Contents.transform.position = shaftPosition + jointTransform.forward * (-dist);
-            // Contents.transform.rotation = shaftRotation;
             Quaternion rot = Contents.transform.rotation;
+            Transform palmTransform = handJointService.RequestJointTransform(TrackedHandJoint.Palm, Handedness.Left);
+            Specials.transform.rotation = palmTransform.rotation;
+            Specials.transform.position = palmTransform.position;
+
             if(pastRotation != Quaternion.identity)
             {
+                // 角速度計算、axisが回転軸、angleが回転量
                 Quaternion deltaRotation = Quaternion.Inverse(pastRotation) * jointTransform.rotation;
                 deltaRotation.ToAngleAxis(out float angle, out Vector3 axis);
                 float angularSpeed = (angle * Mathf.Deg2Rad) / Time.deltaTime;
                 _estimatedAngularVelocity = axis * angularSpeed;
 
-                // 角速度がmarginより小さいなら、その方向の角度は固定
+                // 現在のWristに合わせて回転
+                Contents.transform.rotation = jointTransform.rotation;
 
-                Contents.transform.rotation = shaftRotation;
-
-                // 没案（細かく補正をかけようとすると逆に処理が重くなる）
-                // float dx = _estimatedAngularVelocity.x * Time.deltaTime;
-                // float dy = _estimatedAngularVelocity.y * Time.deltaTime;
-                // float dz = _estimatedAngularVelocity.z * Time.deltaTime;
-                // if(dx >= margin)
-                // {
-                //     Vector3 xaxis = new Vector3(axis.x, 0.0f, 0.0f);
-                //     Contents.transform.Rotate(xaxis, -angle);
-                // }
-                // if(dy >= margin)
-                // {
-                //     Vector3 yaxis = new Vector3(0.0f, axis.y, 0.0f);
-                //     Contents.transform.Rotate(yaxis, -angle);
-                // }
-                // if(dz >= margin)
-                // {
-                //     Vector3 zaxis = new Vector3(0.0f, 0.0f, axis.z);
-                //     Contents.transform.Rotate(zaxis, -angle);
-                // }
-                Debug.Log("old " + Contents.transform.rotation.ToString("F4"));
-                // 今、最初の位置で完全に角度が固定されるような実装になっている
-                Contents.transform.Rotate(axis, -angle);
-                Debug.Log("new " + Contents.transform.rotation.ToString("F4"));
-                Contents.transform.position = jointTransform.position;
+                // 入力するタイミングだけ固定されればいい、右手の人差し指をトリガーにする
+                if(HandJointUtils.TryGetJointPose(TrackedHandJoint.IndexTip, Handedness.Right, out MixedRealityPose rpose))
+                {
+                    // Wristの回転分逆回転で戻す
+                    Contents.transform.Rotate(axis, -angle);
+                    Contents.transform.position = jointTransform.position;
+                }
+                else
+                {
+                    // 逆回転せず、位置だけ更新
+                    Contents.transform.position = jointTransform.position;
+                }
             }
             else
             {
+                // Wristに追従する形
                 Contents.transform.rotation = jointTransform.rotation;
                 Contents.transform.position = jointTransform.position;
             }
             pastRotation = Contents.transform.rotation;
-            // Debug.Log("Wrist " + jointTransform.rotation.ToString("F4") + " shaft " + Contents.transform.rotation.ToString("F4"));
+            Debug.Log("Contents " + Contents.transform.position + " Specials " + Specials.transform.position);
         }
         else
         {
             Contents.SetActive(false);
+            Specials.SetActive(false);
             pastRotation = Quaternion.identity;
-            // pastPosition = defaultPosition;
         }
     }
 }

--- a/Flick Keyboards/Assets/Scripts/HandPosition.cs
+++ b/Flick Keyboards/Assets/Scripts/HandPosition.cs
@@ -4,54 +4,91 @@ using UnityEngine;
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.UI;
+using Microsoft.MixedReality.Toolkit;
 
 
 public class HandPosition : MonoBehaviour
 {
     [SerializeField] GameObject Contents;
+    [SerializeField] float margin;
+    [SerializeField] float dist;
+    private Vector3 _estimatedAngularVelocity = Vector3.zero;
+    private Vector3 shaftPosition;
+    private Quaternion shaftRotation;
+    private Quaternion pastRotation = Quaternion.identity;
+    public Vector3 EstimatedAngularVelocity
+    {
+        get { return _estimatedAngularVelocity; }
+    }
 
     // Start is called before 
     void Start()
     {
         Contents.SetActive(false);
-        /*
-        flickbutton_A.SetActive(false);
-        flickbutton_K.SetActive(false);
-        flickbutton_S.SetActive(false);
-        flickbutton_T.SetActive(false);
-        flickbutton_N.SetActive(false);
-        flickbutton_H.SetActive(false);
-        */
     }
 
     // Update is called once per frame
     void Update()
     {
-        if(HandJointUtils.TryGetJointPose(TrackedHandJoint.IndexTip, Handedness.Left, out MixedRealityPose pose))
+        var handJointService = CoreServices.GetInputSystemDataProvider<IMixedRealityHandJointService>();
+        if(HandJointUtils.TryGetJointPose(TrackedHandJoint.Palm, Handedness.Left, out MixedRealityPose pose))
         {
             Contents.SetActive(true);
-            /*
-            flickbutton_A.SetActive(true);
-            flickbutton_K.SetActive(true);
-            flickbutton_S.SetActive(true);
-            flickbutton_T.SetActive(true);
-            flickbutton_N.SetActive(true);
-            flickbutton_H.SetActive(true);
-            if(flickbutton_A.activeSelf) Debug.Log("arive");
-            */
+            Transform jointTransform = handJointService.RequestJointTransform(TrackedHandJoint.Wrist, Handedness.Left);
+            shaftPosition = jointTransform.position + jointTransform.forward * (-dist);
+            shaftRotation = jointTransform.rotation;
+            // Contents.transform.position = shaftPosition + jointTransform.forward * (-dist);
+            // Contents.transform.rotation = shaftRotation;
+            Quaternion rot = Contents.transform.rotation;
+            if(pastRotation != Quaternion.identity)
+            {
+                Quaternion deltaRotation = Quaternion.Inverse(pastRotation) * jointTransform.rotation;
+                deltaRotation.ToAngleAxis(out float angle, out Vector3 axis);
+                float angularSpeed = (angle * Mathf.Deg2Rad) / Time.deltaTime;
+                _estimatedAngularVelocity = axis * angularSpeed;
+
+                // 角速度がmarginより小さいなら、その方向の角度は固定
+
+                Contents.transform.rotation = shaftRotation;
+
+                // 没案（細かく補正をかけようとすると逆に処理が重くなる）
+                // float dx = _estimatedAngularVelocity.x * Time.deltaTime;
+                // float dy = _estimatedAngularVelocity.y * Time.deltaTime;
+                // float dz = _estimatedAngularVelocity.z * Time.deltaTime;
+                // if(dx >= margin)
+                // {
+                //     Vector3 xaxis = new Vector3(axis.x, 0.0f, 0.0f);
+                //     Contents.transform.Rotate(xaxis, -angle);
+                // }
+                // if(dy >= margin)
+                // {
+                //     Vector3 yaxis = new Vector3(0.0f, axis.y, 0.0f);
+                //     Contents.transform.Rotate(yaxis, -angle);
+                // }
+                // if(dz >= margin)
+                // {
+                //     Vector3 zaxis = new Vector3(0.0f, 0.0f, axis.z);
+                //     Contents.transform.Rotate(zaxis, -angle);
+                // }
+                Debug.Log("old " + Contents.transform.rotation.ToString("F4"));
+                // 今、最初の位置で完全に角度が固定されるような実装になっている
+                Contents.transform.Rotate(axis, -angle);
+                Debug.Log("new " + Contents.transform.rotation.ToString("F4"));
+                Contents.transform.position = jointTransform.position;
+            }
+            else
+            {
+                Contents.transform.rotation = jointTransform.rotation;
+                Contents.transform.position = jointTransform.position;
+            }
+            pastRotation = Contents.transform.rotation;
+            // Debug.Log("Wrist " + jointTransform.rotation.ToString("F4") + " shaft " + Contents.transform.rotation.ToString("F4"));
         }
         else
         {
             Contents.SetActive(false);
-            /*
-            Debug.Log("Lost");
-            flickbutton_A.SetActive(false);
-            flickbutton_K.SetActive(false);
-            flickbutton_S.SetActive(false);
-            flickbutton_T.SetActive(false);
-            flickbutton_N.SetActive(false);
-            flickbutton_H.SetActive(false);
-            */
+            pastRotation = Quaternion.identity;
+            // pastPosition = defaultPosition;
         }
     }
 }

--- a/Flick Keyboards/Assets/Scripts/HandPosition.cs
+++ b/Flick Keyboards/Assets/Scripts/HandPosition.cs
@@ -11,8 +11,8 @@ public class HandPosition : MonoBehaviour
 {
     [SerializeField] GameObject Contents;
     [SerializeField] GameObject Specials;
-    [SerializeField] float ydist;
-    [SerializeField] float buttonangle;
+    [SerializeField] float ydist;   // Contentsから離す距離
+    [SerializeField] float buttonangle; // ボタン自身の角度
     [SerializeField] float margin;  // 今回は0.02f
     private float dist = 0.2f;
     private float buttontheta;

--- a/Flick Keyboards/Assets/Scripts/HandPosition.cs
+++ b/Flick Keyboards/Assets/Scripts/HandPosition.cs
@@ -14,7 +14,7 @@ public class HandPosition : MonoBehaviour
     [SerializeField] float ydist;   // Contentsから離す距離
     [SerializeField] float buttonangle; // ボタン自身の角度
     [SerializeField] float margin;  // 今回は0.02f
-    private float dist = 0.2f;
+    private float dist = 0.18f;
     private float buttontheta;
     private float calc_distance_y, calc_distance_z;
     private float calc_margin_y, calc_margin_z;

--- a/Flick Keyboards/Assets/Scripts/HandPosition.cs
+++ b/Flick Keyboards/Assets/Scripts/HandPosition.cs
@@ -13,8 +13,8 @@ public class HandPosition : MonoBehaviour
     [SerializeField] GameObject Specials;
     [SerializeField] float ydist;   // Contentsから離す距離
     [SerializeField] float buttonangle; // ボタン自身の角度
-    [SerializeField] float margin;  // 今回は0.02f
-    private float dist = 0.18f;
+    [SerializeField] float margin;  // 今回は0.02f, ボタンのサイズが0.02fだから
+    private float dist = 0.22f;
     private float buttontheta;
     private float calc_distance_y, calc_distance_z;
     private float calc_margin_y, calc_margin_z;
@@ -29,7 +29,6 @@ public class HandPosition : MonoBehaviour
     void Start()
     {
         Contents.SetActive(false);
-        Specials.SetActive(false);
         buttontheta = Mathf.PI * (90.0f - buttonangle) / 180.0f;
         calc_distance_y = -(ydist + dist * Mathf.Sin(buttontheta));
         calc_distance_z = -(dist * Mathf.Cos(buttontheta));
@@ -44,12 +43,8 @@ public class HandPosition : MonoBehaviour
         if(HandJointUtils.TryGetJointPose(TrackedHandJoint.Palm, Handedness.Left, out MixedRealityPose lpose))
         {
             Contents.SetActive(true);
-            Specials.SetActive(true);
             Transform jointTransform = handJointService.RequestJointTransform(TrackedHandJoint.Wrist, Handedness.Left);
             Quaternion rot = Contents.transform.rotation;
-            Transform palmTransform = handJointService.RequestJointTransform(TrackedHandJoint.Palm, Handedness.Left);
-            Specials.transform.rotation = palmTransform.rotation;
-            Specials.transform.position = palmTransform.position;
 
             if(pastRotation != Quaternion.identity)
             {
@@ -88,7 +83,6 @@ public class HandPosition : MonoBehaviour
         else
         {
             Contents.SetActive(false);
-            Specials.SetActive(false);
             pastRotation = Quaternion.identity;
         }
     }
@@ -102,15 +96,7 @@ public class HandPosition : MonoBehaviour
             if(obj.name[0] == 'F')
             {
                 obj.transform.localRotation = Quaternion.Euler(-buttonangle, 0, -90);
-                // 今の状態だとその場で回転しているだけなのでローカル座標もうまくいじる
-                if(cnt == 0 || cnt == 6)
-                {
-                    obj.transform.localPosition = new Vector3(obj.transform.localPosition.x, calc_distance_y, calc_distance_z);
-                }
-                else
-                {
-                    obj.transform.localPosition = new Vector3(obj.transform.localPosition.x, calc_distance_y + calc_margin_y*(cnt%6), calc_distance_z + calc_margin_z*(cnt%6));
-                }
+                obj.transform.localPosition = new Vector3(obj.transform.localPosition.x, calc_distance_y + calc_margin_y*(cnt%8), calc_distance_z + calc_margin_z*(cnt%8));
             }
             cnt++;
         }


### PR DESCRIPTION
## 左腕の上にキーボードと入力画面を表示する

### 概要
* 左腕の上にキーボードを配置することによる触覚フィードバックの提供
* 基本的なキーボード構成は同じ
* WristのJointの座標と回転角に連動してキーボードが動く
  * 入力時（右手人差し指を認識したとき）手首の回転角を受けないようになっている

### 手首の上下左右の角度の影響を受けないようにする

#### 変更前
* 手首の小さな動きに反応して、キーボードが腕から飛び出してしまう
  * `Wrist`単体の回転角の変動分はキーボードに反映しないようにしたい

#### 変更後
* `Wrist`の回転角を取得し、その回転分キーボードを逆回転する
  * `deltaRotation`が`Wrist`の回転分
    * `angle`が変動量、`axis`が回転軸を表している
  * `Contents.transform.Rotate(axis, -angle)`で変動量分を戻している

実装のイメージ
<img src="https://user-images.githubusercontent.com/45482966/126041239-d052c38c-a82a-40ba-9ab2-4bfd9439999a.jpg" width="500">



#### 現在の問題点
* 手が認識された角度で固定されてしまうので、腕に埋まった角度で生成されたら再生成しないといけない
* 何かをトリガーとして固定するようにするか、生成位置を最適化するか…

#### 没になっている案
* `Wrist`のx, y, z軸、それぞれの変動量分だけ戻す
  * 少し処理が重くなるのと、軸の計算がよくわからなかったから検討しなおし
* 変動量が小さい場合固定するようにする
  * 角速度の計算をもとに作ってみたが上手くいかなかった

### その他変更点
* ボタンのサイズ変更
  * ボタンのサイズを3/4に変更したが操作感は問題ない
  * 半分ぐらいにしてもいいかもしれない

* 手の認識コードを新しくした
  * `TrackedHandJoint`を`IndexTip`で指定していたが、この設定が左手の人差し指をメインに認識してるらしい
    * ここを`Palm`や`Wrist`に変えることで手の認識を変えることができる
    * `Wrist`は認識が弱そう

* 手のマッピングを戻している
  * 作業が終わったら戻すようにする